### PR TITLE
Updated component name from 'bars' to 'list

### DIFF
--- a/app/07.js
+++ b/app/07.js
@@ -1,4 +1,4 @@
-Vue.component('bars', {
+Vue.component('list', {
     template: '<ul><li v-for="item in items" v-if="item.show" v-on:click="hide(item, $event)">{{item.label}}</li></ul>',
     props: ['items'],
     methods:{


### PR DESCRIPTION
Corrected component name from 'bars' to 'list' in the 07.js to match the 07,html code example